### PR TITLE
delete dependabot for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,14 +13,6 @@ updates:
       gomod-all:
         patterns:
           - "*"
-  - package-ecosystem: "docker"
-    directories:
-      - "/"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-      time: "12:00"
-      timezone: "Asia/Tokyo"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I couldn't find the Dockerfile, so I deleted the Dependabot configuration for it.